### PR TITLE
Bugfix for Ambiguous Local Time

### DIFF
--- a/lib/ri_cal/component/t_z_info_timezone.rb
+++ b/lib/ri_cal/component/t_z_info_timezone.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 #
 # A wrapper class for a Timezone implemented by the TZInfo Gem
@@ -111,8 +112,8 @@ class RiCal::Component::TZInfoTimezone < RiCal::Component::Timezone
   end
   
   # convert time from this time zone to utc time
-  def local_to_utc(time)
-    @tzinfo_timezone.local_to_utc(time.to_ri_cal_ruby_value)
+  def local_to_utc(time, dst_ambiguity=nil)
+    @tzinfo_timezone.local_to_utc(time.to_ri_cal_ruby_value, dst_ambiguity)
   end
 
   # convert time from utc time to this time zone
@@ -126,7 +127,9 @@ class RiCal::Component::TZInfoTimezone < RiCal::Component::Timezone
   end
 
   def export_local_to(export_stream, local_start, local_end) #:nodoc:
-    export_utc_to(export_stream, local_to_utc(local_start.to_ri_cal_ruby_value), local_to_utc(local_end.to_ri_cal_ruby_value))
+    export_utc_to(export_stream, 
+                  local_to_utc(local_start.to_ri_cal_ruby_value, true),
+                  local_to_utc(local_end.to_ri_cal_ruby_value, false))
   end
 
   def to_rfc2445_string(utc_start, utc_end) #:nodoc:

--- a/spec/ri_cal/component/t_z_info_timezone_spec.rb
+++ b/spec/ri_cal/component/t_z_info_timezone_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
 require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
@@ -56,5 +57,13 @@ ENDDATA
         end
       end
     end
+  end
+
+  it "should not raise an error with Ambigous times" do
+    tz = RiCal::Component::TZInfoTimezone.new(TZInfo::Timezone.get("America/New_York"))
+    local_start = DateTime.parse("2011-11-06T01:30:00+00:00")
+    # This time appears twice. Because at 2:00 am the clock falls back to 1:00 am again
+    local_end = DateTime.parse("Nov 30, 2012")
+    lambda { tz.export_local_to(StringIO.new, local_start, local_end) }.should_not raise_error(TZInfo::AmbiguousTime)
   end
 end


### PR DESCRIPTION
Nov 6, 2011 between 1-2am occurs twice and causes ambigous
local time exception.

This fix was suggested here:

http://groups.google.com/group/rical_gem/browse_thread/thread/dbfd63c6d671d486